### PR TITLE
remove lefthook from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "format": "prettier --list-different --write \"src/**/*.{ts,tsx,md}\"",
-    "postinstall": "lefthook install"
+    "format": "prettier --list-different --write \"src/**/*.{ts,tsx,md}\""
   },
   "exports": {
     ".": {


### PR DESCRIPTION
According to the [documentation](https://lefthook.dev/usage/commands.html#lefthook-install):

> NPM package lefthook installs the hooks in a postinstall script automatically

So we don't need to include it in tee-verifier's postinstall. This should fix #1 